### PR TITLE
Add admin chat page with WebSocket server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,9 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/joho/godotenv v1.5.1
 	github.com/swaggo/files v1.0.1
-	github.com/swaggo/gin-swagger v1.6.0
-	github.com/swaggo/swag v1.16.4
+       github.com/swaggo/gin-swagger v1.6.0
+       github.com/swaggo/swag v1.16.4
+       github.com/gorilla/websocket v1.5.1
 )
 
 require (

--- a/routes/adm/r_admin.go
+++ b/routes/adm/r_admin.go
@@ -45,6 +45,20 @@ func SetupAdminRoutes(rg *gin.RouterGroup) {
 		})
 	})
 
+	rg.GET("/chat", func(c *gin.Context) {
+		pageUtil.RenderPageCheckLogin(c, "", 0)
+
+		userId, _ := util.GetContextVal(c, "user_id")
+		userType, _ := util.GetContextVal(c, "user_type")
+		menuData := pageUtil.MakeMenuRole(c, userType, false)
+
+		pageUtil.RenderPage(c, "chat", gin.H{
+			"Menus":    menuData,
+			"UserName": "홍길동",
+			"MyID":     userId,
+		})
+	})
+
 	adminGroup := rg.Group("/manage")
 	{
 

--- a/routes/chat_ws.go
+++ b/routes/chat_ws.go
@@ -1,0 +1,127 @@
+package routes
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+)
+
+type chatMessage struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Content string `json:"content"`
+	Time    int64  `json:"time"`
+}
+
+type chatClient struct {
+	id   string
+	conn *websocket.Conn
+	hub  *chatHub
+	send chan chatMessage
+}
+
+type chatHub struct {
+	mu      sync.Mutex
+	clients map[string]map[*chatClient]bool
+	history map[string][]chatMessage
+}
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+var hub = newChatHub()
+
+func newChatHub() *chatHub {
+	h := &chatHub{
+		clients: make(map[string]map[*chatClient]bool),
+		history: make(map[string][]chatMessage),
+	}
+	return h
+}
+
+func (h *chatHub) register(c *chatClient) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.clients[c.id] == nil {
+		h.clients[c.id] = make(map[*chatClient]bool)
+	}
+	h.clients[c.id][c] = true
+	// send history
+	for _, m := range h.history[c.id] {
+		c.send <- m
+	}
+}
+
+func (h *chatHub) unregister(c *chatClient) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if cl, ok := h.clients[c.id]; ok {
+		if _, ok := cl[c]; ok {
+			delete(cl, c)
+			close(c.send)
+		}
+		if len(cl) == 0 {
+			delete(h.clients, c.id)
+		}
+	}
+}
+
+func (h *chatHub) broadcast(msg chatMessage) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.history[msg.To] = append(h.history[msg.To], msg)
+	if cl, ok := h.clients[msg.To]; ok {
+		for c := range cl {
+			select {
+			case c.send <- msg:
+			default:
+				close(c.send)
+				delete(cl, c)
+			}
+		}
+	}
+}
+
+func (c *chatClient) readPump(target string) {
+	defer func() {
+		c.hub.unregister(c)
+		c.conn.Close()
+	}()
+	for {
+		var msg chatMessage
+		if err := c.conn.ReadJSON(&msg); err != nil {
+			break
+		}
+		if msg.To == "" {
+			msg.To = target
+		}
+		c.hub.broadcast(msg)
+	}
+}
+
+func (c *chatClient) writePump() {
+	for msg := range c.send {
+		c.conn.WriteJSON(msg)
+	}
+}
+
+// ChatWebSocket handles /ws endpoint
+func ChatWebSocket(c *gin.Context) {
+	userID := c.Query("user")
+	target := c.Query("target")
+	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	if err != nil {
+		return
+	}
+	client := &chatClient{id: userID, conn: conn, hub: hub, send: make(chan chatMessage, 8)}
+	hub.register(client)
+	go client.writePump()
+	client.readPump(target)
+}
+
+func SetupChatRoutes(r *gin.Engine) {
+	r.GET("/ws", ChatWebSocket)
+}

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -57,6 +57,8 @@ func SetupRoutes(r *gin.Engine) {
 		out.SetupOutRoutes(outGroup)
 	}
 
+	SetupChatRoutes(r)
+
 	// // 템플릿 에러 핸들링용 fallback route
 	// r.NoRoute(func(c *gin.Context) {
 	// 	pageUtil.RenderPage(c, "error", gin.H{

--- a/templates/adm/pages/chat.tmpl
+++ b/templates/adm/pages/chat.tmpl
@@ -1,0 +1,91 @@
+{{define "title"}}실시간 채팅{{end}}
+
+{{define "content"}}
+<div id="chat-app" class="flex h-[80vh] border rounded bg-white overflow-hidden">
+    <div class="flex-1 flex flex-col">
+        <div class="p-2 bg-gray-100 flex justify-between items-center">
+            <span v-if="currentUser">{{currentUser.u_name}} ({{currentUser.u_id}})</span>
+            <span v-else class="text-gray-500">대화 상대를 선택하세요</span>
+            <button v-if="currentUser" @click="leaveChat" class="text-sm text-red-500">나가기</button>
+        </div>
+        <div ref="chatBox" class="flex-1 overflow-y-auto p-2 space-y-2 bg-gray-50">
+            <div v-for="m in messages" :key="m.time" :class="m.from===myId ? 'text-right' : 'text-left'">
+                <span class="inline-block px-2 py-1 rounded bg-blue-100" v-text="m.content"></span>
+            </div>
+        </div>
+        <div class="p-2 flex border-t" v-if="currentUser">
+            <input v-model="newMessage" @keyup.enter="sendMessage" class="flex-1 border rounded px-2" placeholder="메시지 입력" />
+            <button @click="sendMessage" class="ml-2 px-3 bg-blue-600 text-white rounded">전송</button>
+        </div>
+    </div>
+    <div class="w-60 border-l overflow-y-auto">
+        <h3 class="p-2 font-semibold border-b">사용자 목록</h3>
+        <div v-for="u in users" :key="u.u_id" @click="selectUser(u)" class="p-2 cursor-pointer hover:bg-gray-100" :class="{'bg-gray-200': currentUser && currentUser.u_id===u.u_id}">
+            {{u.u_name}} ({{u.u_id}})
+        </div>
+    </div>
+</div>
+
+<script>
+const { createApp, ref, onMounted, nextTick } = Vue;
+createApp({
+    setup() {
+        const users = ref([]);
+        const currentUser = ref(null);
+        const messages = ref([]);
+        const newMessage = ref('');
+        const ws = ref(null);
+        const myId = '{{.MyID}}';
+        const chatBox = ref(null);
+
+        const fetchUsers = async () => {
+            const res = await fetch('/adm/api/users');
+            const data = await res.json();
+            users.value = data.data;
+        };
+
+        const connect = () => {
+            if (ws.value) ws.value.close();
+            if (!currentUser.value) return;
+            const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+            ws.value = new WebSocket(`${proto}://${location.host}/ws?user=${myId}&target=${currentUser.value.u_id}`);
+            ws.value.onmessage = (e) => {
+                const msg = JSON.parse(e.data);
+                messages.value.push(msg);
+                nextTick(() => {
+                    if (chatBox.value) chatBox.value.scrollTop = chatBox.value.scrollHeight;
+                });
+            };
+            ws.value.onclose = () => { ws.value = null; };
+            messages.value = [];
+        };
+
+        const selectUser = (u) => {
+            currentUser.value = u;
+            connect();
+        };
+
+        const sendMessage = () => {
+            if (!newMessage.value || !ws.value) return;
+            const msg = {from: myId, to: currentUser.value.u_id, content: newMessage.value, time: Date.now()};
+            ws.value.send(JSON.stringify(msg));
+            messages.value.push(msg);
+            newMessage.value = '';
+            nextTick(() => {
+                if (chatBox.value) chatBox.value.scrollTop = chatBox.value.scrollHeight;
+            });
+        };
+
+        const leaveChat = () => {
+            if (ws.value) ws.value.close();
+            ws.value = null;
+            currentUser.value = null;
+            messages.value = [];
+        };
+
+        onMounted(fetchUsers);
+        return { users, currentUser, messages, newMessage, selectUser, sendMessage, leaveChat, chatBox, myId };
+    }
+}).mount('#chat-app');
+</script>
+{{end}}


### PR DESCRIPTION
## Summary
- add WebSocket-based chat hub and route
- register `/ws` endpoint in routing
- expose admin chat page to send messages to users
- include user id in admin chat template
- depend on gorilla/websocket

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24.1)*
- `go test ./...` *(fails: go.mod requires go >= 1.24.1)*

------
https://chatgpt.com/codex/tasks/task_e_683ffcccbfb4832eb7f7f29ac9a1665c